### PR TITLE
Fix cache spam in debug

### DIFF
--- a/Prism/src/main/java/network/darkhelmet/prism/players/PlayerIdentification.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/players/PlayerIdentification.java
@@ -40,7 +40,7 @@ public class PlayerIdentification {
         PrismPlayer prismPlayer = getPrismPlayer(playerName);
         if (prismPlayer != null) {
             // prismPlayer = comparePlayerToCache( player, prismPlayer );
-            Prism.debug("Loaded player " + prismPlayer.getName() + ", id: " + prismPlayer.getId() + " into the cache.");
+            // Prism.debug("Loaded player " + prismPlayer.getName() + ", id: " + prismPlayer.getId() + " into the cache.");
             // Prism.prismPlayers.put( player.getUniqueId(), prismPlayer );
             return prismPlayer;
         }


### PR DESCRIPTION
Here, the PrismPlayer is actually always loaded from cache, I'm not sure why we put it here. It just creates a lots spam, blocking us to check other useful debug messages.