### PR TITLE
Cleanup dataSource configuring, fix hikari default values, type not case-sensitive anymore

### DIFF
--- a/Prism/src/main/java/network/darkhelmet/prism/database/PrismDatabaseFactory.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/database/PrismDatabaseFactory.java
@@ -102,7 +102,7 @@ public class PrismDatabaseFactory {
                 Prism.warn("ERROR: This version of Prism no longer supports Derby. Please use Hikari.");
                 break;
             default:
-                Prism.warn("ERROR: Prism doesn't have a rule for " + dataSource + " datasource. Please use MySQL or Hikari.");
+                Prism.warn("ERROR: Prism doesn't have a rule for " + dataSource + " datasource type. Please use MySQL or Hikari.");
                 break;
         }
         return database;
@@ -117,8 +117,7 @@ public class PrismDatabaseFactory {
         if (configuration == null) {
             return null;
         }
-        String dataSource = configuration.getString("datasource.type").toUpperCase(Locale.ROOT);
-        switch (dataSource) {
+        switch (configuration.getString("datasource.type").toUpperCase(Locale.ROOT)) {
             case "MYSQL":
             case "HIKARI":
                 return new SqlPrismDataSourceUpdater(database);

--- a/Prism/src/main/java/network/darkhelmet/prism/database/mysql/PrismHikariDataSource.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/database/mysql/PrismHikariDataSource.java
@@ -22,15 +22,12 @@ public class PrismHikariDataSource extends SqlPrismDataSource {
             dbConfig = new HikariConfig(propFile.getPath());
         } else {
             Prism.log("You may need to adjust these settings for your setup.");
-            Prism.log("To set a table prefix you will need to create a config entry under");
-            Prism.log("prism:");
-            Prism.log("  datasource:");
-            Prism.log("    prefix: your-prefix");
+            Prism.log("To change the table prefix you will need to edit datasource.properties.prefix entry in config.yml");
             String jdbcUrl = "jdbc:mysql://localhost:3306/prism?useUnicode=true&characterEncoding=UTF-8&useSSL=false";
             Prism.log("Default jdbcUrl: " + jdbcUrl);
             Prism.log("Default Username: username");
             Prism.log("Default Password: password");
-            Prism.log("You will need to provide the required jar libraries that support your database.");
+            Prism.log("You may need to provide the required jar libraries(driver) that support your database.");
             dbConfig = new HikariConfig();
             dbConfig.setJdbcUrl(jdbcUrl);
             dbConfig.setUsername("username");

--- a/Prism/src/main/java/network/darkhelmet/prism/database/mysql/PrismHikariDataSource.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/database/mysql/PrismHikariDataSource.java
@@ -35,6 +35,8 @@ public class PrismHikariDataSource extends SqlPrismDataSource {
             dbConfig.setJdbcUrl(jdbcUrl);
             dbConfig.setUsername("username");
             dbConfig.setPassword("password");
+            dbConfig.setMinimumIdle(2);
+            dbConfig.setMaximumPoolSize(10);
             HikariHelper.createPropertiesFile(propFile, dbConfig, false);
         }
     }
@@ -57,6 +59,9 @@ public class PrismHikariDataSource extends SqlPrismDataSource {
             return this;
         } catch (HikariPool.PoolInitializationException e) {
             Prism.warn("Hikari Pool did not Initialize: " + e.getMessage());
+            database = null;
+        } catch (IllegalArgumentException e) {
+            Prism.warn("Hikari Pool did not Initialize: " + e);
             database = null;
         }
         return this;


### PR DESCRIPTION
Fix type detect.
Fix default HikariConfig throws IllegalArgumentException, because of -1 values.
Remove unnecessary section/null checks, because we set the default value for config.