### PR TITLE
Fix undo action type check

### DIFF
--- a/Prism/src/main/java/network/darkhelmet/prism/commands/UndoCommand.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/commands/UndoCommand.java
@@ -69,13 +69,6 @@ public class UndoCommand implements SubHandler {
                 return;
             }
 
-            // We only support this for drains
-            if (!process.getProcessChildActionType().equals("prism-drain")) {
-                Prism.messenger.sendMessage(call.getPlayer(),
-                        Prism.messenger.playerError("You can't currently undo anything other than a drain process."));
-                return;
-            }
-
             // Pull the actual block change data for this undo event
             final QueryParameters parameters = new QueryParameters();
             parameters.setWorld(call.getPlayer().getWorld().getName());

--- a/Prism/src/main/java/network/darkhelmet/prism/commands/UndoCommand.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/commands/UndoCommand.java
@@ -69,6 +69,13 @@ public class UndoCommand implements SubHandler {
                 return;
             }
 
+            // We only support this for drains
+            if (!process.getProcessChildActionType().equals("prism-drain")) {
+                Prism.messenger.sendMessage(call.getPlayer(),
+                        Prism.messenger.playerError("You can't currently undo anything other than a drain process."));
+                return;
+            }
+
             // Pull the actual block change data for this undo event
             final QueryParameters parameters = new QueryParameters();
             parameters.setWorld(call.getPlayer().getWorld().getName());

--- a/Prism/src/main/java/network/darkhelmet/prism/database/sql/SqlSelectProcessQuery.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/database/sql/SqlSelectProcessQuery.java
@@ -49,9 +49,9 @@ public class SqlSelectProcessQuery extends SqlSelectQueryBuilder implements Sele
 
     protected String where() {
         final int action_id = Prism.prismActions.get("prism-process");
-        String playerName = parameters.getKeyword();
         if (getLastID) {
             //bit hacky here we are using the id parameter which should generally refer to a player.
+            String playerName = parameters.getKeyword();
             return "WHERE action_id = " + action_id + " AND p.player = '" + playerName + "' ";
         }
         //bit hacky here we are using the id parameter which should generally refer to a player.

--- a/Prism/src/main/java/network/darkhelmet/prism/database/sql/SqlSelectProcessQuery.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/database/sql/SqlSelectProcessQuery.java
@@ -48,15 +48,15 @@ public class SqlSelectProcessQuery extends SqlSelectQueryBuilder implements Sele
     }
 
     protected String where() {
+        final int action_id = Prism.prismActions.get("prism-process");
+        String playerName = parameters.getKeyword();
         if (getLastID) {
             //bit hacky here we are using the id parameter which should generally refer to a player.
-            final int action_id = Prism.prismActions.get("prism-process");
-            String playerName = parameters.getKeyword();
             return "WHERE action_id = " + action_id + " AND p.player = '" + playerName + "' ";
         }
         //bit hacky here we are using the id parameter which should generally refer to a player.
         final long id = parameters.getId();
-        return "WHERE d.id = " + id + " ";
+        return "WHERE d.action_id = " + action_id + " AND d.id = " + id + " ";
     }
 
     @Override


### PR DESCRIPTION
`final PrismProcessAction process = aq.getPrismProcessRecord(recordId);` always creates a `PrismProcessAction` even the provided ID to query is not a `prism-process` action.
Added the statement to force it's a `prism-process`.

Fixed https://github.com/Rothes/PrismRefracted/issues/7