### PR TITLE
Fix for rollback not working for bedrock players

### DIFF
--- a/Prism/src/main/java/network/darkhelmet/prism/parameters/PlayerParameter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/parameters/PlayerParameter.java
@@ -16,7 +16,7 @@ public class PlayerParameter extends SimplePrismParameterHandler {
      * A parameter that handles a player.
      */
     public PlayerParameter() {
-        super("Player", Pattern.compile("[~|!]?[\\w,]+"), "p");
+        super("Player", Pattern.compile("[~|!]?\\*?[\\w,]+"), "p");
     }
 
     /**


### PR DESCRIPTION
Prism did not support the * character in the floodgate nickname. 