### PR TITLE
Fix for correct rollback of heads

### DIFF
--- a/Prism/src/main/java/network/darkhelmet/prism/actions/BlockAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/BlockAction.java
@@ -533,6 +533,7 @@ public class BlockAction extends GenericAction {
         if (!s.owner.isEmpty()) {
             final Skull skull = (Skull) state;
             skull.setOwningPlayer(Bukkit.getOfflinePlayer(EntityUtils.uuidOf((s.owner))));
+            skull.update();
         }
         BlockStateChangeImpl stateChange = new BlockStateChangeImpl(originalBlock, state);
         return new ChangeResultImpl(ChangeResultType.APPLIED, stateChange);

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/BlockAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/BlockAction.java
@@ -530,7 +530,7 @@ public class BlockAction extends GenericAction {
         setBlockRotatable(state, s);
         state = block.getState();
 
-        if (!s.owner.isEmpty()) {
+        if (s.owner != null && !s.owner.isEmpty()) {
             final Skull skull = (Skull) state;
             skull.setOwningPlayer(Bukkit.getOfflinePlayer(EntityUtils.uuidOf((s.owner))));
             skull.update();


### PR DESCRIPTION
[TESTING, DO NOT MERGE] Without skull.update(), the default head is restored.