### PR TITLE
Not serializing Java defaults to compress JSON size

### DIFF
--- a/Prism/src/main/java/network/darkhelmet/prism/actions/GenericAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/GenericAction.java
@@ -4,6 +4,10 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.actionlibs.ActionTypeImpl;
+import network.darkhelmet.prism.actions.typeadapter.BoolIgnoreFalseAdapter;
+import network.darkhelmet.prism.actions.typeadapter.IntIgnoreZeroAdapter;
+import network.darkhelmet.prism.actions.typeadapter.LongIgnoreZeroAdapter;
+import network.darkhelmet.prism.actions.typeadapter.ShortIgnoreZeroAdapter;
 import network.darkhelmet.prism.api.ChangeResult;
 import network.darkhelmet.prism.api.PrismParameters;
 import network.darkhelmet.prism.api.actions.ActionType;
@@ -23,7 +27,12 @@ import java.util.UUID;
 public abstract class GenericAction implements Handler {
     private static final SimpleDateFormat date = new SimpleDateFormat("yy/MM/dd");
     private static final SimpleDateFormat time = new SimpleDateFormat("hh:mm:ssa");
-    private static final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+    private static final Gson gson = new GsonBuilder().disableHtmlEscaping()
+            .registerTypeAdapter(Integer.class, new IntIgnoreZeroAdapter())
+            .registerTypeAdapter(Short.class, new ShortIgnoreZeroAdapter())
+            .registerTypeAdapter(Boolean.class, new BoolIgnoreFalseAdapter())
+            .registerTypeAdapter(Long.class, new LongIgnoreZeroAdapter())
+            .create();
     private boolean canceled = false;
     private ActionType type;
 

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/data/ItemStackActionData.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/data/ItemStackActionData.java
@@ -4,7 +4,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.annotations.JsonAdapter;
 import net.md_5.bungee.chat.ComponentSerializer;
 import network.darkhelmet.prism.Prism;
-import network.darkhelmet.prism.actions.typeadapter.ItemNiceNameIgnoreEmptyAdapter;
+import network.darkhelmet.prism.actions.typeadapter.ItemNameIgnoreEmptyAdapter;
 import network.darkhelmet.prism.api.objects.MaterialState;
 import network.darkhelmet.prism.utils.EntityUtils;
 import network.darkhelmet.prism.utils.ItemUtils;
@@ -20,7 +20,6 @@ import org.bukkit.block.ShulkerBox;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.block.banner.PatternType;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.ArmorStand;
 import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -35,8 +34,6 @@ import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.inventory.meta.trim.ArmorTrim;
-import org.bukkit.inventory.meta.trim.TrimMaterial;
-import org.bukkit.inventory.meta.trim.TrimPattern;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionType;
 
@@ -51,7 +48,7 @@ import java.util.stream.Collectors;
 public class ItemStackActionData {
     public int amt;
     public Material material;
-    @JsonAdapter(ItemNiceNameIgnoreEmptyAdapter.class)
+    @JsonAdapter(ItemNameIgnoreEmptyAdapter.class)
     public String name;
     public int color;
     public String owner;

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/data/ItemStackActionData.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/data/ItemStackActionData.java
@@ -1,8 +1,10 @@
 package network.darkhelmet.prism.actions.data;
 
 import com.google.gson.JsonParseException;
+import com.google.gson.annotations.JsonAdapter;
 import net.md_5.bungee.chat.ComponentSerializer;
 import network.darkhelmet.prism.Prism;
+import network.darkhelmet.prism.actions.typeadapter.ItemNiceNameIgnoreEmptyAdapter;
 import network.darkhelmet.prism.api.objects.MaterialState;
 import network.darkhelmet.prism.utils.EntityUtils;
 import network.darkhelmet.prism.utils.ItemUtils;
@@ -49,6 +51,7 @@ import java.util.stream.Collectors;
 public class ItemStackActionData {
     public int amt;
     public Material material;
+    @JsonAdapter(ItemNiceNameIgnoreEmptyAdapter.class)
     public String name;
     public int color;
     public String owner;
@@ -68,7 +71,7 @@ public class ItemStackActionData {
     public String potionType;
     public boolean potionExtended;
     public boolean potionUpgraded;
-    public Boolean hasTrim;
+    public boolean hasTrim;
     public NamespacedKey trimMaterial;
     public NamespacedKey trimPattern;
     public Map<Integer, ItemStackActionData> shulkerBoxInv;  // Deprecated

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/BoolIgnoreFalseAdapter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/BoolIgnoreFalseAdapter.java
@@ -1,0 +1,32 @@
+package network.darkhelmet.prism.actions.typeadapter;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class BoolIgnoreFalseAdapter extends TypeAdapter<Boolean> {
+    private static final Boolean BOOL_FALSE = false;
+
+    @Override
+    public Boolean read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return false;
+        }
+
+        return in.nextBoolean();
+    }
+
+    @Override
+    public void write(JsonWriter out, Boolean data) throws IOException {
+        if (data == null || data.equals(BOOL_FALSE)) {
+            out.nullValue();
+            return;
+        }
+
+        out.value(data.booleanValue());
+    }
+}

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/IntIgnoreZeroAdapter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/IntIgnoreZeroAdapter.java
@@ -1,0 +1,32 @@
+package network.darkhelmet.prism.actions.typeadapter;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class IntIgnoreZeroAdapter extends TypeAdapter<Integer> {
+    private static final Integer INT_ZERO = 0;
+
+    @Override
+    public Integer read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return 0;
+        }
+
+        return in.nextInt();
+    }
+
+    @Override
+    public void write(JsonWriter out, Integer data) throws IOException {
+        if (data == null || data.equals(INT_ZERO)) {
+            out.nullValue();
+            return;
+        }
+
+        out.value(data.intValue());
+    }
+}

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/ItemNameIgnoreEmptyAdapter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/ItemNameIgnoreEmptyAdapter.java
@@ -7,7 +7,7 @@ import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
 
-public class ItemNiceNameIgnoreEmptyAdapter extends TypeAdapter<String> {
+public class ItemNameIgnoreEmptyAdapter extends TypeAdapter<String> {
 
     @Override
     public String read(JsonReader in) throws IOException {

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/ItemNiceNameIgnoreEmptyAdapter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/ItemNiceNameIgnoreEmptyAdapter.java
@@ -1,0 +1,31 @@
+package network.darkhelmet.prism.actions.typeadapter;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class ItemNiceNameIgnoreEmptyAdapter extends TypeAdapter<String> {
+
+    @Override
+    public String read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return "";
+        }
+
+        return in.nextString();
+    }
+
+    @Override
+    public void write(JsonWriter out, String data) throws IOException {
+        if (data == null || data.isEmpty()) {
+            out.nullValue();
+            return;
+        }
+
+        out.value(data);
+    }
+}

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/LongIgnoreZeroAdapter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/LongIgnoreZeroAdapter.java
@@ -1,0 +1,32 @@
+package network.darkhelmet.prism.actions.typeadapter;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class LongIgnoreZeroAdapter extends TypeAdapter<Long> {
+    private static final Long LONG_ZERO = 0L;
+
+    @Override
+    public Long read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return 0L;
+        }
+
+        return in.nextLong();
+    }
+
+    @Override
+    public void write(JsonWriter out, Long data) throws IOException {
+        if (data == null || data.equals(LONG_ZERO)) {
+            out.nullValue();
+            return;
+        }
+
+        out.value(data.intValue());
+    }
+}

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/ShortIgnoreZeroAdapter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/ShortIgnoreZeroAdapter.java
@@ -1,0 +1,32 @@
+package network.darkhelmet.prism.actions.typeadapter;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class ShortIgnoreZeroAdapter extends TypeAdapter<Short> {
+    private static final Short SHORT_ZERO = 0;
+
+    @Override
+    public Short read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return 0;
+        }
+
+        return (short) in.nextInt();
+    }
+
+    @Override
+    public void write(JsonWriter out, Short data) throws IOException {
+        if (data == null || data.equals(SHORT_ZERO)) {
+            out.nullValue();
+            return;
+        }
+
+        out.value(data.intValue());
+    }
+}


### PR DESCRIPTION
This patch makes the following changes:

* If the item name is null (empty string in ActionData), then not on serialization and restore the empty string on deserialization to maintain the same behavior.
* If the value of Integer/Long/Short is 0, then it is not retained during serialization.
* If the value of Boolean is false, then it is not retained during serialization.

The size of JSON is significantly reduced and avoids changes to existing code structures and is fully compatible with older versions of databases without the need for upgrade steps.

| Status | Proof |
| --- | --- |
| Before | ![image](https://github.com/Rothes/PrismRefracted/assets/30802565/b3bb1cd1-87b0-48ff-8d54-0a279d3a1d2e) |
| After | ![image](https://github.com/Rothes/PrismRefracted/assets/30802565/bc12214d-e7f6-4f20-9672-a2844a313a86) |


