### PR TITLE
Ignore default values and compress json length as much as possible

### DIFF
--- a/Prism/src/main/java/network/darkhelmet/prism/actions/BlockAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/BlockAction.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.api.ChangeResult;
 import network.darkhelmet.prism.api.ChangeResultType;
@@ -648,10 +649,12 @@ public class BlockAction extends GenericAction {
      * @author botskonet
      */
     static class BlockActionData {
+        @SerializedName(value = "c", alternate = {"customName"})
         String customName = "";
     }
 
     public static class CommandActionData extends BlockActionData {
+        @SerializedName(value = "c", alternate = {"command"})
         String command;
     }
 
@@ -661,8 +664,9 @@ public class BlockAction extends GenericAction {
      * @author botskonet
      */
     public static class SpawnerActionData extends BlockActionData {
-
+        @SerializedName(value = "e", alternate = {"entityType"})
         String entityType;
+        @SerializedName(value = "d", alternate = {"delay"})
         int delay;
 
         EntityType getEntityType() {
@@ -675,6 +679,7 @@ public class BlockAction extends GenericAction {
     }
 
     public static class RotatableActionData extends BlockActionData {
+        @SerializedName(value = "r", alternate = {"rotation"})
         String rotation;
 
         BlockFace getRotation() {
@@ -692,7 +697,7 @@ public class BlockAction extends GenericAction {
      * @author botskonet
      */
     public static class SkullActionData extends RotatableActionData {
-
+        @SerializedName(value = "o", alternate = {"owner"})
         String owner;
 
     }
@@ -702,6 +707,7 @@ public class BlockAction extends GenericAction {
         /**
          * BACK, LEFT, RIGHT, FRONT on Spigot 1.20.1
          */
+        @SerializedName(value = "s", alternate = {"sherds"})
         Material[] sherds;
 
     }
@@ -713,15 +719,22 @@ public class BlockAction extends GenericAction {
      * @author botskonet
      */
     public static class SignActionData extends BlockActionData {
+        @SerializedName(value = "l", alternate = {"lines"})
         String[] lines;
+        @SerializedName(value = "c", alternate = {"color"})
         DyeColor color;
+        @SerializedName(value = "g", alternate = {"glowing"})
         boolean glowing;
+        @SerializedName(value = "bl", alternate = {"backLines"})
         String[] backLines;
+        @SerializedName(value = "bc", alternate = {"backColor"})
         DyeColor backColor;
+        @SerializedName(value = "bg", alternate = {"backGlowing"})
         boolean backGlowing;
     }
 
     public static class BannerActionData extends RotatableActionData {
+        @SerializedName(value = "p", alternate = {"patterns"})
         Map<String, String> patterns;
     }
 

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/BlockFallAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/BlockFallAction.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
 import org.bukkit.Location;
 
 public class BlockFallAction extends BlockChangeAction {
@@ -60,6 +61,7 @@ public class BlockFallAction extends BlockChangeAction {
     }
 
     public static class BlockFallActionData {
+        @SerializedName(value = "s", alternate = {"start"})
         boolean start;
         int x;
         int y;

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/EntityTravelAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/EntityTravelAction.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -91,6 +92,7 @@ public class EntityTravelAction extends GenericAction {
         int x;
         int y;
         int z;
+        @SerializedName(value = "c", alternate = {"cause"})
         String cause;
     }
 }

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/GenericAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/GenericAction.java
@@ -4,10 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.actionlibs.ActionTypeImpl;
-import network.darkhelmet.prism.actions.typeadapter.BoolIgnoreFalseAdapter;
-import network.darkhelmet.prism.actions.typeadapter.IntIgnoreZeroAdapter;
-import network.darkhelmet.prism.actions.typeadapter.LongIgnoreZeroAdapter;
-import network.darkhelmet.prism.actions.typeadapter.ShortIgnoreZeroAdapter;
+import network.darkhelmet.prism.actions.typeadapter.*;
 import network.darkhelmet.prism.api.ChangeResult;
 import network.darkhelmet.prism.api.PrismParameters;
 import network.darkhelmet.prism.api.actions.ActionType;
@@ -32,6 +29,7 @@ public abstract class GenericAction implements Handler {
             .registerTypeAdapter(Short.class, new ShortIgnoreZeroAdapter())
             .registerTypeAdapter(Boolean.class, new BoolIgnoreFalseAdapter())
             .registerTypeAdapter(Long.class, new LongIgnoreZeroAdapter())
+            .registerTypeAdapter(Material.class, new MaterialIdAdapter())
             .create();
     private boolean canceled = false;
     private ActionType type;

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/HangingItemAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/HangingItemAction.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.api.ChangeResult;
 import network.darkhelmet.prism.api.ChangeResultType;
@@ -149,8 +150,11 @@ public class HangingItemAction extends GenericAction {
 
     @SuppressWarnings("WeakerAccess")
     public static class HangingItemActionData {
+        @SerializedName(value = "t", alternate = {"type"})
         public String type;
+        @SerializedName(value = "d", alternate = {"direction"})
         public String direction;
+        @SerializedName(value = "a", alternate = {"art"})
         public String art;
     }
 }

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/ItemStackAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/ItemStackAction.java
@@ -109,6 +109,7 @@ public class ItemStackAction extends GenericAction {
         if (data == null || !data.startsWith("{")) {
             return;
         }
+
         actionData = gson().fromJson(data, ItemStackActionData.class);
 
         // Old extra data doesn't include the material so
@@ -116,6 +117,7 @@ public class ItemStackAction extends GenericAction {
         if (materialState != null && actionData.material == null) {
             actionData.material = materialState.material;
         }
+
 
         item = actionData.toItem();
     }

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/PlayerAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/PlayerAction.java
@@ -1,6 +1,9 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
+
 public class PlayerAction extends GenericAction {
+    @SerializedName(value = "eI", alternate = {"extraInfo"})
 
     private String extraInfo;
 

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/PlayerDeathAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/PlayerDeathAction.java
@@ -1,10 +1,13 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.Objects;
 
 public class PlayerDeathAction extends GenericAction {
-
+    @SerializedName(value = "c", alternate = {"cause"})
     private String cause;
+    @SerializedName(value = "a", alternate = {"attacker"})
 
     private String attacker;
 

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/PrismProcessAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/PrismProcessAction.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.api.actions.PrismProcessType;
 
@@ -59,7 +60,9 @@ public class PrismProcessAction extends GenericAction {
     }
 
     public static class PrismProcessActionData {
+        @SerializedName(value = "p", alternate = {"params"})
         public String params = "";
+        @SerializedName(value = "pt", alternate = {"processType"})
         public String processType;
     }
 }

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/SignChangeAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/SignChangeAction.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.api.ChangeResult;
 import network.darkhelmet.prism.api.ChangeResultType;
@@ -194,10 +195,15 @@ public class SignChangeAction extends GenericAction {
     }
 
     public static class SignChangeActionData {
+        @SerializedName(value = "fs", alternate = {"frontSide"})
         public boolean frontSide = true;
+        @SerializedName(value = "ol", alternate = {"oldLines"})
         public String[] oldLines;
+        @SerializedName(value = "l", alternate = {"lines"})
         public String[] lines;
+        @SerializedName(value = "st", alternate = {"signType"})
         public String signType;
+        @SerializedName(value = "f", alternate = {"facing"})
         public BlockFace facing;
     }
 }

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/SignDyeAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/SignDyeAction.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.api.BlockStateChange;
 import network.darkhelmet.prism.api.ChangeResult;
@@ -126,8 +127,11 @@ public class SignDyeAction extends GenericAction {
     }
 
     public class SignDyeActionData {
+        @SerializedName(value = "fs", alternate = {"frontSide"})
         public boolean frontSide;
+        @SerializedName(value = "oc", alternate = {"oldColor"})
         public DyeColor oldColor;
+        @SerializedName(value = "nc", alternate = {"newColor"})
         public DyeColor newColor;
     }
 

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/SignGlowAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/SignGlowAction.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.api.ChangeResult;
 import network.darkhelmet.prism.api.ChangeResultType;
@@ -117,7 +118,9 @@ public class SignGlowAction extends GenericAction {
     }
 
     public class SignGlowActionData {
+        @SerializedName(value = "fs", alternate = {"frontSide"})
         public boolean frontSide;
+        @SerializedName(value = "mg", alternate = {"makeGlow"})
         public boolean makeGlow;
     }
 

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/VehicleAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/VehicleAction.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.api.ChangeResult;
 import network.darkhelmet.prism.api.ChangeResultType;
@@ -134,7 +135,9 @@ public class VehicleAction extends GenericAction {
     }
 
     public static class VehicleActionData {
+        @SerializedName(value = "vn", alternate = {"vehicleName"})
         String vehicleName;
+        @SerializedName(value = "wt", alternate = {"woodType"})
         String woodType;
     }
 }

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/data/ItemStackActionData.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/data/ItemStackActionData.java
@@ -2,9 +2,11 @@ package network.darkhelmet.prism.actions.data;
 
 import com.google.gson.JsonParseException;
 import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
 import net.md_5.bungee.chat.ComponentSerializer;
 import network.darkhelmet.prism.Prism;
 import network.darkhelmet.prism.actions.typeadapter.ItemNameIgnoreEmptyAdapter;
+import network.darkhelmet.prism.actions.typeadapter.SlotIgnoreNegativeOneAdapter;
 import network.darkhelmet.prism.api.objects.MaterialState;
 import network.darkhelmet.prism.utils.EntityUtils;
 import network.darkhelmet.prism.utils.ItemUtils;
@@ -46,32 +48,59 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ItemStackActionData {
+    @SerializedName(value = "a", alternate = {"amt", "amount"})
     public int amt;
+    @SerializedName(value = "m", alternate = {"material"})
     public Material material;
     @JsonAdapter(ItemNameIgnoreEmptyAdapter.class)
+    @SerializedName(value = "n", alternate = {"name"})
     public String name;
+    @SerializedName(value = "c", alternate = {"color"})
     public int color;
+    @SerializedName(value = "o", alternate = {"owner"})
     public String owner;
+    @SerializedName(value = "e", alternate = {"enchs"})
     public String[] enchs;
+    @SerializedName(value = "b", alternate = {"by"})
     public String by;
+    @SerializedName(value = "t", alternate = {"title"})
     public String title;
+    @SerializedName(value = "g", alternate = {"generation"})
     public BookMeta.Generation generation;
+    @SerializedName(value = "l", alternate = {"lore"})
     public String[] lore;
+    @SerializedName(value = "ct", alternate = {"content"})
     public String[] content;
+    @SerializedName(value = "s", alternate = {"slot"})
+    @JsonAdapter(SlotIgnoreNegativeOneAdapter.class)
     public String slot = "-1";
+    @SerializedName(value = "ec", alternate = {"effectColors"})
     public int[] effectColors;
+    @SerializedName(value = "fc", alternate = {"fadeColors"})
     public int[] fadeColors;
+    @SerializedName(value = "hf", alternate = {"hasFlicker"})
     public boolean hasFlicker;
+    @SerializedName(value = "ht", alternate = {"hasTrail"})
     public boolean hasTrail;
+    @SerializedName(value = "d", alternate = {"durability"})
     public short durability = 0;
+    @SerializedName(value = "bm", alternate = {"bannerMeta"})
     public Map<String, String> bannerMeta;
+    @SerializedName(value = "pt", alternate = {"potionType"})
     public String potionType;
+    @SerializedName(value = "pe", alternate = {"potionExtended"})
     public boolean potionExtended;
+    @SerializedName(value = "pu", alternate = {"potionUpgraded"})
     public boolean potionUpgraded;
+    @SerializedName(value = "htm", alternate = {"hasTrim"})
     public boolean hasTrim;
+    @SerializedName(value = "tm", alternate = {"trimMaterial"})
     public NamespacedKey trimMaterial;
+    @SerializedName(value = "tp", alternate = {"trimPattern"})
     public NamespacedKey trimPattern;
+    @SerializedName(value = "si", alternate = {"shulkerBoxInv"})
     public Map<Integer, ItemStackActionData> shulkerBoxInv;  // Deprecated
+    @SerializedName(value = "bi", alternate = {"blockInventory"})
     public Map<Integer, ItemStackActionData> blockInventory;
 
     public static ItemStackActionData createData(ItemStack item, int quantity, short durability, Map<Enchantment, Integer> enchantments) {

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/AbstractHorseSerializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/AbstractHorseSerializer.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.utils.ItemUtils;
 import network.darkhelmet.prism.utils.MiscUtils;
 import org.bukkit.attribute.Attribute;
@@ -12,15 +13,25 @@ import org.bukkit.entity.Horse;
 import org.bukkit.entity.Llama;
 
 public class AbstractHorseSerializer extends EntitySerializer {
+    @SerializedName(value = "c", alternate = {"horseColor"})
     protected String horseColor = null;
+    @SerializedName(value = "s", alternate = {"style"})
     protected String style = null;
+    @SerializedName(value = "sd", alternate = {"saddle"})
     protected String saddle = null;
+    @SerializedName(value = "a", alternate = {"armor"})
     protected String armor = null;
+    @SerializedName(value = "ch", alternate = {"chest"})
     protected Boolean chest = null;
+    @SerializedName(value = "d", alternate = {"dom"})
     protected int dom = 0;
+    @SerializedName(value = "md", alternate = {"maxDom"})
     protected int maxDom = 20;
+    @SerializedName(value = "j", alternate = {"jump"})
     protected double jump = 1.0;
+    @SerializedName(value = "mh", alternate = {"maxHealth"})
     protected double maxHealth = 20.0;
+    @SerializedName(value = "ms", alternate = {"movementSpeed"})
     protected double movementSpeed = 0.2;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/CatSerializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/CatSerializer.java
@@ -1,10 +1,12 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.utils.MiscUtils;
 import org.bukkit.entity.Cat;
 import org.bukkit.entity.Entity;
 
 public class CatSerializer extends EntitySerializer {
+    @SerializedName(value = "v", alternate = {"var"})
     protected String var = null;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/EntitySerializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/EntitySerializer.java
@@ -1,6 +1,8 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
+import network.darkhelmet.prism.actions.typeadapter.BoolIgnoreTrueAdapter;
 import network.darkhelmet.prism.utils.EntityUtils;
 import network.darkhelmet.prism.utils.MiscUtils;
 import org.bukkit.OfflinePlayer;
@@ -15,20 +17,24 @@ import org.bukkit.event.entity.EntityDamageEvent;
 
 public class EntitySerializer {
     //@todo remove alternates after 2.1.7 release
+    @SerializedName(value = "ad", alternate = {"isAdult"})
+    @JsonAdapter(BoolIgnoreTrueAdapter.class)
     protected Boolean isAdult = null;
+    @SerializedName(value = "sit", alternate = {"sitting"})
     protected Boolean sitting = null;
 
-    @SerializedName(value = "entityName", alternate = "entity_name")
+    @SerializedName(value = "en", alternate = {"entity_name", "entityName"})
     protected String entityName = null;
 
-    @SerializedName(value = "customName", alternate = "custom_name")
+    @SerializedName(value = "cn", alternate = {"custom_name", "customName"})
     protected String customName = null;
 
-    @SerializedName(value = "tamingOwner", alternate = "taming_owner")
+    @SerializedName(value = "to", alternate = {"taming_owner", "tamingOwner"})
     protected String tamingOwner = null;
+    @SerializedName(value = "nc", alternate = {"newColor"})
     protected String newColor = null;
 
-    @SerializedName(value = "customDesc", alternate = "custom_desc")
+    @SerializedName(value = "cd", alternate = {"custom_desc","customDesc"})
     protected String customDesc = null;
 
     public final String getEntityName() {

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/MerchantSerializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/MerchantSerializer.java
@@ -1,5 +1,6 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.actions.data.ItemStackActionData;
 import org.bukkit.entity.Entity;
 import org.bukkit.inventory.ItemStack;
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MerchantSerializer extends EntitySerializer {
+    @SerializedName(value = "rdl", alternate = {"recipeDataList"})
     protected List<RecipeData> recipeDataList = null;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/PandaSerializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/PandaSerializer.java
@@ -1,11 +1,14 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.utils.MiscUtils;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Panda;
 
 public class PandaSerializer extends EntitySerializer {
+    @SerializedName(value = "mg", alternate = {"mainGene"})
     protected String mainGene = null;
+    @SerializedName(value = "hg", alternate = {"hiddenGene"})
     protected String hiddenGene = null;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/ParrotSerializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/ParrotSerializer.java
@@ -1,10 +1,12 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.utils.MiscUtils;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Parrot;
 
 public class ParrotSerializer extends EntitySerializer {
+    @SerializedName(value = "v", alternate = {"var"})
     protected String var = null;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/SheepSerializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/SheepSerializer.java
@@ -1,11 +1,13 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.utils.MiscUtils;
 import org.bukkit.DyeColor;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Sheep;
 
 public class SheepSerializer extends EntitySerializer {
+    @SerializedName(value = "c", alternate = {"color"})
     protected String color = null;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/VillagerSerializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/VillagerSerializer.java
@@ -1,14 +1,19 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.utils.MiscUtils;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.Villager.Profession;
 
 public class VillagerSerializer extends MerchantSerializer {
+    @SerializedName(value = "p", alternate = {"profession"})
     protected String profession = null;
+    @SerializedName(value = "t", alternate = {"type"})
     protected String type = null;
+    @SerializedName(value = "l", alternate = {"level"})
     protected int level = -1;
+    @SerializedName(value = "e", alternate = {"experience"})
     protected int experience = -1;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/WanderingTraderSerializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/WanderingTraderSerializer.java
@@ -1,9 +1,11 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.WanderingTrader;
 
 public class WanderingTraderSerializer extends MerchantSerializer {
+    @SerializedName(value = "d", alternate = {"despawnDelay"})
     protected int despawnDelay;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/WolfSerlializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/WolfSerlializer.java
@@ -1,11 +1,13 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.utils.MiscUtils;
 import org.bukkit.DyeColor;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Wolf;
 
 public class WolfSerlializer extends EntitySerializer {
+    @SerializedName(value = "c", alternate = {"color"})
     protected String color = null;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/entity/ZombieVillagerSerlializer.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/entity/ZombieVillagerSerlializer.java
@@ -1,11 +1,13 @@
 package network.darkhelmet.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import network.darkhelmet.prism.utils.MiscUtils;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Villager.Profession;
 import org.bukkit.entity.ZombieVillager;
 
 public class ZombieVillagerSerlializer extends EntitySerializer {
+    @SerializedName(value = "p", alternate = {"profession"})
     protected String profession = null;
 
     @Override

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/BoolIgnoreTrueAdapter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/BoolIgnoreTrueAdapter.java
@@ -1,0 +1,32 @@
+package network.darkhelmet.prism.actions.typeadapter;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class BoolIgnoreTrueAdapter extends TypeAdapter<Boolean> {
+    private static final Boolean BOOL_TRUE = true;
+
+    @Override
+    public Boolean read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return true;
+        }
+
+        return in.nextBoolean();
+    }
+
+    @Override
+    public void write(JsonWriter out, Boolean data) throws IOException {
+        if (data == null || data.equals(BOOL_TRUE)) {
+            out.nullValue();
+            return;
+        }
+
+        out.value(data.booleanValue());
+    }
+}

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/MaterialIdAdapter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/MaterialIdAdapter.java
@@ -1,0 +1,39 @@
+package network.darkhelmet.prism.actions.typeadapter;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import network.darkhelmet.prism.Prism;
+import org.bukkit.Material;
+
+import java.io.IOException;
+
+public class MaterialIdAdapter extends TypeAdapter<Material> {
+
+    @Override
+    public Material read(JsonReader in) throws IOException {
+        JsonToken token = in.peek();
+        if (token == JsonToken.NULL) {
+            in.nextNull();
+            return Material.STONE;
+        }
+        if (token == JsonToken.STRING) {
+            return Material.matchMaterial(in.nextString());
+        }
+        if (token == JsonToken.NUMBER) {
+            return Prism.getItems().idsToMaterial(in.nextInt(), 0, false).material;
+        }
+        in.nextNull();
+        return null;
+    }
+
+    @Override
+    public void write(JsonWriter out, Material data) throws IOException {
+        if (data == null || data.isAir()) {
+            out.nullValue();
+            return;
+        }
+        out.value(Prism.getItems().materialToIds(data, "0").first);
+    }
+}

--- a/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/SlotIgnoreNegativeOneAdapter.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/typeadapter/SlotIgnoreNegativeOneAdapter.java
@@ -1,0 +1,32 @@
+package network.darkhelmet.prism.actions.typeadapter;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class SlotIgnoreNegativeOneAdapter extends TypeAdapter<String> {
+    private static final String NEGATIVE_ONE = "-1";
+
+    @Override
+    public String read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return "-1";
+        }
+
+        return in.nextString();
+    }
+
+    @Override
+    public void write(JsonWriter out, String data) throws IOException {
+        if (data == null || data.equals(NEGATIVE_ONE)) {
+            out.nullValue();
+            return;
+        }
+
+        out.value(data);
+    }
+}


### PR DESCRIPTION
This PR compresses JSON size by：

* Specifying SerializedName to shorten the serialized field name
* Use block_id to serialize Material fields, integer is much shorter in most cases
* Stop serialization of field defaults (e.g. isAdult = true, slot = -1) with custom TypeAdapter

This PR saves about 60% of storage space on the production server over 60% storage usage on `data_extra` table.

| Status | Proof |
| ------ | ----- |
| Old    | ![old](https://github.com/prism/PrismRefracted/assets/30802565/cf9699a9-8b93-49a9-ab5e-d706655a954e) |
| New    | ![new](https://github.com/prism/PrismRefracted/assets/30802565/83db7d8d-b489-43b0-8a88-f6f48c0deda3) |




