### PR TITLE
Fix NoSuchMethodError on entity rollback for 1.18

### DIFF
--- a/Prism/src/main/java/network/darkhelmet/prism/actions/EntityAction.java
+++ b/Prism/src/main/java/network/darkhelmet/prism/actions/EntityAction.java
@@ -103,7 +103,8 @@ public class EntityAction extends GenericAction {
             if (!isPreview) {
                 final Location loc = getLoc().add(0.5, 0.0, 0.5);
                 if (entityType.getEntityClass() != null && loc.getWorld() != null) {
-                    loc.getWorld().spawn(loc, entityType.getEntityClass(), entity -> serializer.deserialize(entity));
+                    Entity entity = loc.getWorld().spawn(loc, entityType.getEntityClass());
+                    serializer.deserialize(entity);
                 } else {
                     return new ChangeResultImpl(ChangeResultType.SKIPPED, null);
                 }


### PR DESCRIPTION
## Problem & Fix
When rolling back entities on Spigot 1.18.2, Prism spams a `NoSuchMethodError` until the server is closed. 

This is a very simple fix, instead of calling the `World#spawn()` method that accepts a `Consumer`, it calls the normal `World#spawn()` method, and then calls the deserialize method afterwards. 
